### PR TITLE
Loading jobs, volumes, filesets in configurator, or other tables fails

### DIFF
--- a/vendor/bllim/datatables/src/Bllim/Datatables/Datatables.php
+++ b/vendor/bllim/datatables/src/Bllim/Datatables/Datatables.php
@@ -908,8 +908,9 @@ class Datatables
         foreach ($joins as $join) {
             $table = preg_split("/ as /i", $join->table);
             $names[] = $table[0];
-            if (isset($table[1]) && !empty($this->databasePrefix()) && strpos($table[1], $this->databasePrefix()) == 0) {
-                $names[] = preg_replace('/^'.$this->databasePrefix().'/', '', $table[1]);
+            $prefix = databasePrefix();
+            if (isset($table[1]) && !empty($prefix) && strpos($table[1], $prefix) == 0) {
+                $names[] = preg_replace('/^'.$prefix.'/', '', $table[1]);
             }
         }
 

--- a/vendor/bllim/datatables/src/Bllim/Datatables/Datatables.php
+++ b/vendor/bllim/datatables/src/Bllim/Datatables/Datatables.php
@@ -905,12 +905,12 @@ class Datatables
 
         $names[] = $query->from;
         $joins = $query->joins?:array();
+        $databasePrefix = databasePrefix();
         foreach ($joins as $join) {
             $table = preg_split("/ as /i", $join->table);
             $names[] = $table[0];
-            $prefix = databasePrefix();
-            if (isset($table[1]) && !empty($prefix) && strpos($table[1], $prefix) == 0) {
-                $names[] = preg_replace('/^'.$prefix.'/', '', $table[1]);
+            if (isset($table[1]) && !empty($databasePrefix) && strpos($table[1], $databasePrefix) == 0) {
+                $names[] = preg_replace('/^'.$databasePrefix.'/', '', $table[1]);
             }
         }
 

--- a/vendor/bllim/datatables/src/Bllim/Datatables/Datatables.php
+++ b/vendor/bllim/datatables/src/Bllim/Datatables/Datatables.php
@@ -905,7 +905,7 @@ class Datatables
 
         $names[] = $query->from;
         $joins = $query->joins?:array();
-        $databasePrefix = databasePrefix();
+        $databasePrefix = $this->databasePrefix();
         foreach ($joins as $join) {
             $table = preg_split("/ as /i", $join->table);
             $names[] = $table[0];


### PR DESCRIPTION
It was working with 2.0.7

With 2.0.10 I get this error:
PHP Fatal error:  Can't use method return value in write context in /var/www/clients/client0/web184/reportula/vendor/bllim/datatables/src/Bllim/Datatables/Datatables.php on line 911

Using PHP 5.4.35
